### PR TITLE
Added ReadV2Header()

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -5,9 +5,10 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"net"
+
+	"github.com/pkg/errors"
 )
 
 type Header struct {
@@ -29,11 +30,14 @@ type Header struct {
 	Unknown []byte
 }
 
+var (
+	V1Identifier = []byte("PROXY ")
+	V2Identifier = []byte("\r\n\r\n\x00\r\nQUIT\n")
+)
+
 const (
-	v1Identifier   = "PROXY "
 	v1UnKnownProto = "UNKNOWN"
 	cRLF           = "\r\n"
-	v2Identifier   = "\r\n\r\n\x00\r\nQUIT\n"
 	tlvHeaderLen   = 3
 )
 
@@ -68,7 +72,7 @@ func ReadHeader(r io.Reader) (*Header, error) {
 	}
 
 	// Look for V1 or V2 identifiers
-	if bytes.HasPrefix(buf[0:13], []byte(v2Identifier)) {
+	if bytes.HasPrefix(buf[0:13], V2Identifier) {
 		h, err := readV2Header(buf[0:], r)
 		if err != nil {
 			return nil, errors.Wrap(err, "while parsing proxy proto v2 header")
@@ -76,7 +80,7 @@ func ReadHeader(r io.Reader) (*Header, error) {
 		return h, nil
 	}
 
-	if bytes.HasPrefix(buf[0:13], []byte(v1Identifier)) {
+	if bytes.HasPrefix(buf[0:13], V1Identifier) {
 		h, err := readV1Header(buf[0:], r)
 		if err != nil {
 			return nil, errors.Wrap(err, "while parsing proxy proto v1 header")

--- a/v1_test.go
+++ b/v1_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mailgun/proxyproto"
+	"github.com/mailgun/influx/proxyproto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/v2.go
+++ b/v2.go
@@ -3,15 +3,28 @@ package proxyproto
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"net"
+
+	"github.com/pkg/errors"
 )
 
 const (
 	ipv4AddressLen = 12
 	ipv6AddressLen = 36
 )
+
+// ReadV2Header assumes the first read will contain the identifier, then reads up until the
+// length of the header as specified by the proxy protocol header. If you are using a
+// bufio.Reader you can peek at the first 13 bytes to ensure the header identifier exists
+// before passing the bufio.Reader to this function.
+func ReadV2Header(r io.Reader) (*Header, error) {
+	var buf [232]byte
+	if _, err := io.ReadFull(r, buf[0:13]); err != nil {
+		return nil, errors.Wrap(err, "while reading proxy proto identifier")
+	}
+	return readV2Header(buf[0:], r)
+}
 
 // readV2Header assumes the passed buf contains the first 13 bytes which should look like
 // the following. (Where X is the proto proxy version and command)


### PR DESCRIPTION
## Purpose
Allows users to detect proxy protocol on the wire using a bufio.Peek() then parse the proto with `ReaderV2Header()`. This only works for V2 protocol currently.